### PR TITLE
feat: add profile field to dependency configuration

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -159,7 +159,7 @@ subroutine build_model(model, settings, package_config, error)
                 
                 ! Adapt it to the current profile/platform
                 dependency = dependency_config%export_config(target_platform, &
-                                                             dep%features,verbose=.false.,error=error)
+                                                             dep%features,dep%profile,verbose=.false.,error=error)
                 if (allocated(error)) exit
                 
                 manifest => dependency

--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -9,7 +9,13 @@
 !>"dep3" = { git = "url", tag = "name" }
 !>"dep4" = { git = "url", rev = "sha1" }
 !>"dep0" = { path = "path" }
+!>"dep5" = { path = "path", features = ["feat1", "feat2"] }
+!>"dep6" = { path = "path", profile = "myprofile" }
 !>```
+!>
+!> The `features` and `profile` keys are mutually exclusive.
+!> `features` provides a list of individual feature names;
+!> `profile` provides a single profile name defined in the dependency's manifest.
 !>
 !> To reduce the amount of boilerplate code this module provides two constructors
 !> for dependency types, one basic for an actual dependency (inline) table
@@ -65,6 +71,9 @@ module fpm_manifest_dependency
         
         !> Requested features for the dependency
         type(string_t), allocatable :: features(:)
+
+        !> Requested profile for the dependency (mutually exclusive with features)
+        character(len=:), allocatable :: profile
 
         !> Git descriptor
         type(git_target_t), allocatable :: git
@@ -136,6 +145,9 @@ contains
         call get_list(table, "features", self%features, error)
         if (allocated(error)) return
 
+        !> Get optional profile name
+        call get_value(table, "profile", self%profile)
+
         call get_value(table, "path", uri)
         if (allocated(uri)) then
             if (get_os_type() == OS_WINDOWS) uri = windows_path(uri)
@@ -197,7 +209,8 @@ contains
               "branch", &
               "rev", &
               "preprocess", &
-              "features" &
+              "features", &
+              "profile" &
             & ]
 
         call table%get_key(name)
@@ -252,7 +265,13 @@ contains
             end if
 
         end if
-        
+
+        ! Check that features and profile are not both specified
+        if (table%has_key('features') .and. table%has_key('profile')) then
+            call syntax_error(error, "Dependency '"//name//"' cannot have both 'features' and 'profile' entries")
+            return
+        end if
+
     end subroutine check
 
     !> Construct new dependency array from a TOML data structure
@@ -381,6 +400,10 @@ contains
           end do
        end if
 
+       if (allocated(self%profile)) then
+          write(unit, fmt) " - profile", self%profile
+       end if
+
     end subroutine info
 
     !> Check if two dependency configurations are different
@@ -418,6 +441,7 @@ contains
         if (allocated(self%requested_version)) deallocate(self%requested_version)
         if (allocated(self%git)) deallocate(self%git)
         if (allocated(self%features)) deallocate(self%features)
+        if (allocated(self%profile)) deallocate(self%profile)
 
     end subroutine dependency_destroy
 
@@ -450,7 +474,11 @@ contains
               if (allocated(this%features).neqv.allocated(other%features)) return
               if (allocated(this%features)) then
                 if (.not.(this%features==other%features)) return
-              endif              
+              endif
+              if (allocated(this%profile).neqv.allocated(other%profile)) return
+              if (allocated(this%profile)) then
+                if (.not.(this%profile==other%profile)) return
+              endif
 
               if ((allocated(this%git).neqv.allocated(other%git))) return
               if (allocated(this%git)) then
@@ -493,7 +521,9 @@ contains
              if (allocated(error)) return
         endif
        call set_list(table, "features", self%features, error)
-       if (allocated(error)) return        
+       if (allocated(error)) return
+       call set_string(table, "profile", self%profile, error, 'dependency_config_t')
+       if (allocated(error)) return
 
         if (allocated(self%git)) then
             call add_table(table, "git", ptr, error)
@@ -537,7 +567,8 @@ contains
             endif
         end if
         call get_list(table, "features", self%features, error)
-        if (allocated(error)) return        
+        if (allocated(error)) return
+        call get_value(table, "profile", self%profile)
 
         call table%get_keys(list)
         add_git: do ii = 1, size(list)


### PR DESCRIPTION
## Summary
- Add `profile` (single string) as an alternative to `features` (list) on dependency declarations
- `profile` references a named profile defined in the dependency's manifest
- `features` and `profile` are mutually exclusive; specifying both is a parse error
- Includes serialization, deserialization, equality checks, and cleanup support

## Example usage
```toml
[dependencies]
mylib = { path = "..", profile = "release" }
# OR
mylib = { path = "..", features = ["feat1", "feat2"] }
# but NOT both
```

## Test plan
- [x] `dependency-profile-present`: parse profile key, verify value is correct
- [x] `dependency-profile-absent`: verify profile is unallocated when key is omitted
- [x] `dependency-profile-features-conflict`: reject manifests specifying both features and profile
- [x] All existing tests pass